### PR TITLE
Issue #1: Download all images (and some more…)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
+# Ignore jpg's
+*.jpg
+

--- a/Downloader.groovy
+++ b/Downloader.groovy
@@ -2,46 +2,63 @@
 
 import groovyx.net.http.RESTClient
 
-def meetupKey = '--Key Goes Here, Nice try mr hacker--'
-def directory = '.' //Directory prefix goes here
-def group = '--Group Name--'
+// Example URL: https://www.meetup.com/de-DE/Zurich-Hike-Outdoor/photos/29900145/
+// -> group = Zurich-Hike-Outdoor
+// -> photoAlbumIds = [29900145]
+
+def meetupKey = '--Key Goes Here, Nice try mr hacker--'  // See https://secure.meetup.com/meetup_api/key
+def directory = '.'                // Directory prefix goes here
+def group = '--Group Name--'       // Printable name of group as in URL
+def photoAlbumIds = [--Album ID--] // ID of Albums, to download only certain 
+                                   // albums, not all. Groovy list.
+                                   // set to -1 to download ALL albums
 
 def defaultQueries = [sign: 'true', 'photo-host': 'public', page: 20, key: meetupKey]
 
 def groupMeetup = new RESTClient("https://api.meetup.com/$group/")
 def albums = groupMeetup.get(path: 'photo_albums', query: defaultQueries)
 
-
 albumMap = albums.data.collectEntries {
     [(it.id) : [title:(it.title), created:(new Date(it.created).format("yyyy-MM-dd"))] ]
 }
 
-println "albumMap Size: ${albumMap.size()}"
-
 albumMap.each{
     id, album ->
-        //Make directory
-        def currentDirectory = "$directory/${album.created}_${(album.title).replaceAll("[\\W\\s]+", "")}"
-        new File(currentDirectory).mkdir()
+        if (photoAlbumIds.contains(-1) || photoAlbumIds.contains(id)){
+            // Make directory
+            def currentDirectory = "$directory/${album.created}_${(album.title).replaceAll("[\\W\\s]+", "")}"
+            new File(currentDirectory).mkdir()
 
-        println "Getting all photos for the album ${album.title}"
+            println "Getting all photos for the album ${album.title}"
 
-        //Request all photos under the id
-        def results = groupMeetup.get(path:"photo_albums/$id/photos", query: defaultQueries)
+            // Request all photos under the id, starting from 0
+            def offset = 0
+            def query = defaultQueries + [offset: offset]
+            def results = groupMeetup.get(path:"photo_albums/$id/photos", query: query)
 
-        //Download
-        results.data?.each {
-            String fileName = "$currentDirectory/${it.id}.jpg"
+            // Download, as long as there's something to get
+            while (results.data) {
+                results.data?.each {
+                    // Store caption in filename, if there's one
+                    String caption = "${(it.caption ? "_" + it.caption : "").replaceAll("[\\W\\s]+", "")}"
+                    String fileName = "$currentDirectory/${it.id}${caption}.jpg"
+                    // println "Würde herunterladen: $fileName"
 
-            //If the file does already exist lets not continue
-            if (!new File(fileName).exists()) {
-                println "- Downloading Photo: ${it.id}"
-                new File(fileName).withOutputStream { out ->
-                    out << new URL(it.highres_link).openStream()
+                    // If the file does already exist lets not continue
+                    if (!new File(fileName).exists()) {
+                        println "- Downloading Photo: ${it.id}"
+                        new File(fileName).withOutputStream { out ->
+                            out << new URL(it.highres_link).openStream()
+                        }
+                    } else {
+                        println "- Skipping Photo: ${it.id}"
+                    }
                 }
+                // Get next page of images
+                query = defaultQueries + [offset: offset++]
+                results = groupMeetup.get(path:"photo_albums/$id/photos", query: query)
             }
-            else {
-                println "- Skipping Photo: ${it.id}"
-            }
+
+            println ""
         }
 }

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ This project assumes that Groovy is isntalled on your system.
 ## About the Author 
 
 Steven Hicks is a developer that can be found at http://theexceptioncatcher.com. He has been a self taught, and formally educated developer for nearly 20 years.
+
+## Edits after Forking
+
+ccenergy: Rename folder based on photoalbum created property

--- a/README.md
+++ b/README.md
@@ -4,18 +4,17 @@ This project is intended to download all of the photos from your meetup group by
 
 This project assumes that Groovy is isntalled on your system.
 
-## How to Use 
+## How to Use
 
  1. Modify the following variables in the script: meetupKey, directory, group. The group variable is the textual Group URL name. (This can be found after meetup.com/... as the name).
  2. Run the groovy script as groovy Download.groovy
  3. Wait for the results to finish. When the script is done the console will be ready for another command. If there was an issue with grabbing a file sometimes a 500 will be thrown. Try to run the script again and it may succced.
- 
- 
- 
-## About the Author 
+
+## About the Author
 
 Steven Hicks is a developer that can be found at http://theexceptioncatcher.com. He has been a self taught, and formally educated developer for nearly 20 years.
 
 ## Edits after Forking
 
 ccenergy: Rename folder based on photoalbum created property
+alexs77: Download all pictures from album, not just first page (https://github.com/monksy/meetupphotodownloader/issues/1)


### PR DESCRIPTION
Downloads all the images of an album and not just those on "page" 1 of the results. Important, if an album has more than 20 images.

Additionally, allow to set albums for which images are to be downloaded, so that not all albums are downloaded. Important for huge groups.

And merge what @ccenergy has done.